### PR TITLE
Tidy & rename pages.yml to push-main-deploy-github-pages.yml

### DIFF
--- a/.github/workflows/push-main-deploy-github-pages.yml
+++ b/.github/workflows/push-main-deploy-github-pages.yml
@@ -4,7 +4,7 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages
+name: Deploy Jekyll site to GitHub Pages
 
 on:
   push:
@@ -25,37 +25,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build job
-  build:
+
+  build_static_jekyll_site_artifacts:
     runs-on: ubuntu-latest
     steps:
+
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Setup Pages
+
+      - name: Enable GitHub Pages and extract various metadata
         id: pages
         uses: actions/configure-pages@v3
-      - name: Build with Jekyll
+
+      - name: Build static Jekyll site
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Upload artifact
+
+      - name: Upload static site to GitHub artifacts
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v1
 
-  # Deployment job
-  deploy:
+  deploy_to_github_pages:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: build_static_jekyll_site_artifacts
+    
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
* This change cleans up the GitHub Action that deploys commits to the `main` branch to GitHub Pages.
* No logic has been changed, so the likelihood of breakages is low.
* To verify that this GitHub Action still works, we'll need to merge this to `main` and check the latest commit on `main`.

